### PR TITLE
Split "navigate along calculated route" column

### DIFF
--- a/files/OSMSoftwareConfig.xml
+++ b/files/OSMSoftwareConfig.xml
@@ -396,14 +396,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		</col>
 		<col id="calculateRoute" label="Calculate route" visible="true" primary="false" sortable="true">
 			<label lang="de" text="Route berechnen"/>
-			<mapping key="calculateRoute" from=".*yes.*" to="{{yes}}"/>
-			<mapping key="calculateRoute" from=".+" to="{{no}}"/>
+			<mapping key="calculateRoute" from="(yes|no)" to="{{$1}}"/>
+			<mapping key="calculateRoute" from="(.*)" to="$1"/>
 			<mapping to="{{?}}"/>
 		</col>
 		<col id="calculateRouteOffline" label="Calculate route without internet" visible="true" primary="false" sortable="true">
 			<label lang="de" text="Route berechnen ohne Internet"/>
-			<mapping key="calculateRouteOffline" from=".*yes.*" to="{{yes}}"/>
-			<mapping key="calculateRouteOffline" from=".+" to="{{no}}"/>
+			<mapping key="calculateRouteOffline" from="(yes|no)" to="{{$1}}"/>
+			<mapping key="calculateRouteOffline" from="(.*)" to="$1"/>
 			<mapping to="{{?}}"/>
 		</col>
 		<col id="profile_car" label="Car routing" visible="true" primary="false" sortable="true">
@@ -455,8 +455,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	
 	<columns id="routing_provider_cols">
 		<col id="routing_offline" label="Offline routing" visible="true" primary="false" sortable="true">
-			<mapping key="routingProviders" from=".*(?:offline).*" to="{{yes}}"/>
-			<mapping key="routingProviders" from=".*" to="{{no}}"/>
+			<mapping key="calculateRouteOffline" from="(yes|no)" to="{{$1}}"/>
+			<mapping key="calculateRouteOffline" from="(.*)" to="$1"/>
 			<mapping to="{{?}}"/>
 		</col>
 		<col id="routing_provider_CloudMade" label="CloudMade" visible="true" primary="false" sortable="true">

--- a/files/OSMSoftwareConfig.xml
+++ b/files/OSMSoftwareConfig.xml
@@ -394,10 +394,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<mapping key="navigateRoute" from=".+" to="{{no}}"/>
 			<mapping to="{{?}}"/>
 		</col>
-		<col id="navigateRoute_calc" label="Navigate along calculated route" visible="true" primary="false" sortable="true">
-			<label lang="de" text="Folge einer berechneten Route"/>
-			<mapping key="navigateRoute" from=".*calc.*" to="{{yes}}"/>
-			<mapping key="navigateRoute" from=".+" to="{{no}}"/>
+		<col id="calculateRoute" label="Calculate route" visible="true" primary="false" sortable="true">
+			<label lang="de" text="Route berechnen"/>
+			<mapping key="calculateRoute" from=".*yes.*" to="{{yes}}"/>
+			<mapping key="calculateRoute" from=".+" to="{{no}}"/>
+			<mapping to="{{?}}"/>
+		</col>
+		<col id="calculateRouteOffline" label="Calculate route without internet" visible="true" primary="false" sortable="true">
+			<label lang="de" text="Route berechnen ohne Internet"/>
+			<mapping key="calculateRouteOffline" from=".*yes.*" to="{{yes}}"/>
+			<mapping key="calculateRouteOffline" from=".+" to="{{no}}"/>
 			<mapping to="{{?}}"/>
 		</col>
 		<col id="profile_car" label="Car routing" visible="true" primary="false" sortable="true">


### PR DESCRIPTION
When going off-road, internet is usually not available and it is important feature for a navigation app to be able to re-route in offline mode. => 'Calculate route without internet' column

This is a substitution for (deprecated) 'routing' column and refinement of 'navigateCalc' column.
